### PR TITLE
Hide empty recipe categories during search

### DIFF
--- a/js/search-recipes.js
+++ b/js/search-recipes.js
@@ -91,6 +91,28 @@ function searchElements( query, index ) {
 }
 
 /**
+ * Updates the visibility of recipe categories based on whether they contain any visible recipes.
+ */
+function updateCategoryVisibility( ) {
+    const categories = document.querySelectorAll( '.category-heading' );
+    categories.forEach( category => {
+        const recipes = category.querySelectorAll( '.recipe-item' );
+        let hasVisibleRecipe = false;
+        for ( const recipe of recipes ) {
+            if ( recipe.style.display !== 'none' ) {
+                hasVisibleRecipe = true;
+                break;
+            }
+        }
+        if ( hasVisibleRecipe ) {
+            category.style.display = 'list-item';
+        } else {
+            category.style.display = 'none';
+        }
+    } );
+}
+
+/**
  * Removes diacritics from a string, converting it to a simpler form.
  * For example, "jalapeño" becomes "jalapeno".
  * @param {string} string The string to remove diacritics from.
@@ -121,6 +143,7 @@ function searchKeyboardHandler( ) {
     );
     if ( debugSearchRecipes ) console.log( "query=[%s]", query );
     searchElements( query.split( " " ), recipeIndexArray );
+    updateCategoryVisibility( );
 
     clearTimeout( searchTrackTimer );
     searchTrackTimer = setTimeout( ( ) => {


### PR DESCRIPTION
This change improves the user experience of the recipe browser search by hiding category headings that have no matching recipes. This reduces clutter and helps the user focus on relevant results.

I implemented a new function `updateCategoryVisibility` in `js/search-recipes.js` that checks each `.category-heading` for visible `.recipe-item` descendants. If none are found (i.e., they are all hidden by the search logic), the category heading itself is hidden. I called this function at the end of the `searchKeyboardHandler` to ensure the UI stays in sync with the search query.

Verification was performed using a Playwright script that tested various search scenarios:
1. Initial state (all categories visible).
2. Search matching some recipes in some categories (matching categories shown, others hidden).
3. Search matching nothing (all categories hidden).
4. Clearing search (all categories restored).

---
*PR created automatically by Jules for task [12476325812133252955](https://jules.google.com/task/12476325812133252955) started by @john-costanzo*