### PR TITLE
Fix Ingredients pane collapse in narrow portrait mode

### DIFF
--- a/css/recipe-styles.css
+++ b/css/recipe-styles.css
@@ -314,7 +314,6 @@ amount {
 		flex-direction: column !important;
 		height: auto !important;
 		overflow: visible !important;
-		display: block !important;
 	}
 	#methodCol,
 	#rightCol {
@@ -323,7 +322,6 @@ amount {
 		overflow: visible !important;
 		height: auto !important;
 		border-left: none !important;
-		display: block !important;
 	}
 	.small-text {
 		font-size: 12px;

--- a/recipe_browser.html
+++ b/recipe_browser.html
@@ -10,7 +10,7 @@
 		/>
 		<title>Recipe Browser</title>
 		<script>
-			const recipeBrowserVersion = "Saturday, 2026-04-25 @ 08:59:09";
+			const recipeBrowserVersion = "Sunday, 2026-04-26 @ 17:31:12";
 		</script>
 
 		<!-- Google tag (gtag.js) -->


### PR DESCRIPTION
This change allows the Ingredients and Method panes to collapse correctly when the recipe browser is viewed in narrow portrait mode (max-width: 480px). Previously, a 'display: block !important' rule in the CSS was overriding the 'display: none' set by Dojo's wipeOut animation. The version string in 'recipe_browser.html' has also been updated.

---
*PR created automatically by Jules for task [13275126399378977048](https://jules.google.com/task/13275126399378977048) started by @john-costanzo*