### PR TITLE
Update Recipe Browser Mobile Layout and Timestamps

### DIFF
--- a/css/recipe-styles.css
+++ b/css/recipe-styles.css
@@ -314,6 +314,15 @@ amount {
 		height: auto !important;
 		overflow: visible !important;
 	}
+	#searchCol {
+		order: 1;
+	}
+	#rightCol {
+		order: 2;
+	}
+	#methodCol {
+		order: 3;
+	}
 	#searchCol,
 	#methodCol,
 	#rightCol {
@@ -322,6 +331,10 @@ amount {
 		overflow: visible !important;
 		height: auto !important;
 		border-left: none !important;
+	}
+	.keystroke,
+	.text-align-right {
+		display: none;
 	}
 	.small-text {
 		font-size: 12px;
@@ -379,5 +392,9 @@ amount {
 	}
 	.recipe-clock {
 		display: none !important;
+	}
+	.keystroke,
+	.text-align-right {
+		display: none;
 	}
 }

--- a/js/circular-timer-using-dojo.js
+++ b/js/circular-timer-using-dojo.js
@@ -1,4 +1,4 @@
-const circularTimerVersion = "Monday, 2025-08-11 @ 21:59:37";
+const circularTimerVersion = "Thursday, 2026-05-14 @ 13:20:49";
 
 const zeroPad = ( num, places ) => String( num ).padStart( places, '0' );
 

--- a/js/costanzo-recipes.js
+++ b/js/costanzo-recipes.js
@@ -1,4 +1,4 @@
-const recipeDataVersion = "Wednesday, 2026-05-13 @ 21:23:21";
+const recipeDataVersion = "Thursday, 2026-05-14 @ 13:20:49";
 const tagsArray = [ ];
 const creditsArray = [ ];
 const yieldsArray = [ ];

--- a/js/recipe-scaling.js
+++ b/js/recipe-scaling.js
@@ -1,4 +1,4 @@
-const recipeScalingVersion = "Monday, 2025-12-01 @ 19:10:44";
+const recipeScalingVersion = "Thursday, 2026-05-14 @ 13:20:49";
 
 /*
  *    In response to this prompt:

--- a/js/search-recipes.js
+++ b/js/search-recipes.js
@@ -1,4 +1,4 @@
-const searchRecipesVersion = "Monday, 2025-08-11 @ 21:59:23";
+const searchRecipesVersion = "Thursday, 2026-05-14 @ 13:20:49";
 
 var debugSearchRecipes = false;
 

--- a/recipe_browser.html
+++ b/recipe_browser.html
@@ -10,7 +10,7 @@
 		/>
 		<title>Recipe Browser</title>
 		<script>
-			const recipeBrowserVersion = "Wednesday, 2026-05-13 @ 18:59:41";
+			const recipeBrowserVersion = "Thursday, 2026-05-14 @ 13:20:49";
 		</script>
 
 		<!-- Google tag (gtag.js) -->


### PR DESCRIPTION
This change improves the mobile user experience for the Recipe Browser by reordering the recipe panels (Ingredients now appears before Method on narrow screens) and hiding keyboard shortcut hints that are not applicable to mobile devices. It also synchronizes the version timestamps across the application.

---
*PR created automatically by Jules for task [3642792441444592908](https://jules.google.com/task/3642792441444592908) started by @john-costanzo*