### PR TITLE
Add ingredient-based scaling to recipe browser

### DIFF
--- a/css/recipe-styles.css
+++ b/css/recipe-styles.css
@@ -264,6 +264,10 @@ h8 {
 }
 amount {
 	color: slateblue;
+	cursor: pointer;
+}
+amount:hover {
+	text-decoration: underline;
 }
 .dijitMenuItem {
 	font-size: 18px !important;

--- a/js/recipe-scaling.js
+++ b/js/recipe-scaling.js
@@ -1,4 +1,4 @@
-const recipeScalingVersion = "Thursday, 2026-05-14 @ 13:20:49";
+const recipeScalingVersion = "Tuesday, 2026-06-02 @ 16:00:00";
 
 /*
  *    In response to this prompt:
@@ -22,33 +22,126 @@ const recipeScalingVersion = "Thursday, 2026-05-14 @ 13:20:49";
  * Prompts the user for a scaling percentage and validates the input.
  * @returns {number|null} The user-provided scaling percentage, or null if cancelled.
  */
-function promptForScalingPercentage( ) {
-    // Prompt the user for a scalingPercentage
-    var scalingPercentageText = prompt( "Please enter a percentage with which to scale the recipe:" );
+function promptForScalingPercentage() {
+	// Prompt the user for a scalingPercentage
+	let scalingPercentageText = prompt(
+		"Please enter a percentage with which to scale the recipe:",
+	);
 
-    scalingPercentageText = scalingPercentageText.replace( /\s+/g, '' );
+	if (scalingPercentageText !== null) {
+		scalingPercentageText = scalingPercentageText.replace(/\s+/g, "");
+		if (scalingPercentageText === "") {
+			scalingPercentageText = "100";
+		}
+		if (!/^[\d.]+$/.test(scalingPercentageText)) {
+			alert("Invalid input! Please enter (only) a number.");
+			return;
+		}
 
-    if ( scalingPercentageText !== null ) {
-        if ( scalingPercentageText === "" ) {
-            scalingPercentageText = "100";
-        }
-        if ( !/^[\d.]+$/.test( scalingPercentageText ) ) {
-            alert( "Invalid input! Please enter (only) a number." );
-            return;
-        }
+		// Convert the input to a number
+		const targetScalingPercentage = parseFloat(scalingPercentageText);
 
-        // Convert the input to a number
-        const targetScalingPercentage = parseFloat( scalingPercentageText );
+		// Validate the input
+		if (isNaN(targetScalingPercentage) || targetScalingPercentage < 0) {
+			alert("Invalid input! Please enter a number greater than 0.");
+			return;
+		}
+		return (currentScalingPercentage = targetScalingPercentage);
+	} else {
+		return null;
+	}
+}
 
-        // Validate the input
-        if ( isNaN( targetScalingPercentage ) || targetScalingPercentage < 0 ) {
-            alert( "Invalid input! Please enter a number greater than 0." );
-            return;
-        }
-        return ( currentScalingPercentage = targetScalingPercentage );
-    } else {
-        return ( null );
-    }
+const fractionalTextToGlyphMap = {
+	"1/2": "½",
+	"1/3": "⅓",
+	"2/3": "⅔",
+	"1/4": "¼",
+	"3/4": "¾",
+	"1/5": "⅕",
+	"2/5": "⅖",
+	"3/5": "⅗",
+	"4/5": "⅘",
+	"1/6": "⅙",
+	"5/6": "⅚",
+	"1/7": "⅐",
+	"1/8": "⅛",
+	"3/8": "⅜",
+	"5/8": "⅝",
+	"7/8": "⅞",
+	"1/9": "⅑",
+	"1/10": "⅒",
+};
+
+/**
+ * Parses a string representing an amount (including fractions and glyphs) into a number.
+ * @param {string} text - The text to parse.
+ * @returns {number} The parsed amount as a decimal, or NaN if invalid.
+ */
+function parseAmount(text) {
+	text = text.trim();
+	// Replace glyphs with their fractional text
+	for (const [key, value] of Object.entries(fractionalTextToGlyphMap)) {
+		text = text.replace(value, " " + key + " ");
+	}
+
+	// Split by spaces and process parts
+	const parts = text.split(/\s+/).filter((p) => p.length > 0);
+	let total = 0;
+	let hasValidPart = false;
+	for (const part of parts) {
+		if (part.includes("/")) {
+			const subparts = part.split("/");
+			if (subparts.length === 2) {
+				const num = parseFloat(subparts[0]);
+				const den = parseFloat(subparts[1]);
+				if (!isNaN(num) && !isNaN(den) && den !== 0) {
+					total += num / den;
+					hasValidPart = true;
+				}
+			}
+		} else {
+			const val = parseFloat(part);
+			if (!isNaN(val)) {
+				total += val;
+				hasValidPart = true;
+			}
+		}
+	}
+	return hasValidPart ? total : NaN;
+}
+
+/**
+ * Prompts the user for a new amount for a specific ingredient and scales the entire recipe.
+ * @param {HTMLElement} amountElement - The <amount> element representing the ingredient.
+ * @returns {boolean} True if the recipe was scaled, false otherwise.
+ */
+function scaleRecipeByIngredient(amountElement) {
+	const originalAmount = parseFloat(amountElement.getAttribute("fraction"));
+	if (isNaN(originalAmount)) return false;
+
+	const units = amountElement.getAttribute("units") || "";
+	const currentAmount = originalAmount * (currentScalingPercentage / 100.0);
+	const currentAmountStr = numberToFraction(currentAmount);
+
+	const promptMsg =
+		"Enter a new amount for this ingredient (current: " +
+		currentAmountStr +
+		" " +
+		units +
+		"):";
+	let newAmountText = prompt(promptMsg);
+	if (newAmountText === null) return false;
+
+	const parsedNewAmount = parseAmount(newAmountText);
+	if (isNaN(parsedNewAmount) || parsedNewAmount <= 0) {
+		alert("Invalid amount entered.");
+		return false;
+	}
+
+	const newScalingFactor = parsedNewAmount / originalAmount;
+	currentScalingPercentage = newScalingFactor * 100;
+	return true;
 }
 
 /**
@@ -117,27 +210,6 @@ function updateAmounts( scaling_factor ) {
     }
 }
 
-
-const fractionalTextToGlyphMap = {
-    "1/2": "½",
-    "1/3": "⅓",
-    "2/3": "⅔",
-    "1/4": "¼",
-    "3/4": "¾",
-    "1/5": "⅕",
-    "2/5": "⅖",
-    "3/5": "⅗",
-    "4/5": "⅘",
-    "1/6": "⅙",
-    "5/6": "⅚",
-    "1/7": "⅐",
-    "1/8": "⅛",
-    "3/8": "⅜",
-    "5/8": "⅝",
-    "7/8": "⅞",
-    "1/9": "⅑",
-    "1/10": "⅒",
-};
 
 /**
  * Converts a number to a string representation of a fraction.

--- a/recipe_browser.html
+++ b/recipe_browser.html
@@ -10,7 +10,7 @@
 		/>
 		<title>Recipe Browser</title>
 		<script>
-			const recipeBrowserVersion = "Sunday, 2026-05-24 @ 10:55:58";
+			const recipeBrowserVersion = "Tuesday, 2026-06-02 @ 16:00:00";
 		</script>
 
 		<!-- Google tag (gtag.js) -->
@@ -471,9 +471,35 @@
 
 			/**
 			 * Toggles the 'itemClicked' class on an element and its children to de-emphasize it.
+			 * Also handles scaling if the click was on an amount or the bullet.
 			 * @param {HTMLElement} element - The element that was clicked.
 			 */
 			function handleItemClick(element) {
+				const event = window.event;
+				if (event) {
+					const target = event.target;
+					let amountElement = undefined;
+
+					// If we clicked on an <amount> tag, use it.
+					if (target.tagName.toLowerCase() === "amount") {
+						amountElement = target;
+					}
+					// If we clicked on the bullet (offsetX < 0) of an LI, find its first <amount> child.
+					else if (
+						element.tagName.toLowerCase() === "li" &&
+						event.offsetX < 0
+					) {
+						amountElement = element.querySelector("amount");
+					}
+
+					if (amountElement) {
+						if (scaleRecipeByIngredient(amountElement)) {
+							redirectHere();
+						}
+						return;
+					}
+				}
+
 				element.classList.toggle("itemClicked");
 
 				// Now apply styles to all child elements


### PR DESCRIPTION
The recipe browser now supports scaling by an individual ingredient. Users can click on an ingredient's amount or its bullet point to be prompted for a new amount. The entire recipe will then be scaled proportionally based on the ratio between the new amount and the original amount.

Key changes:
- `js/recipe-scaling.js`: New `parseAmount` utility handles decimals, mixed fractions (e.g., "1 1/2"), and Unicode fraction glyphs (e.g., "½"). `scaleRecipeByIngredient` calculates the new global scaling factor.
- `recipe_browser.html`: Updated `handleItemClick` to leverage `window.event` for hit-testing clicks against list bullets and amount tags.
- `css/recipe-styles.css`: Added `cursor: pointer` and hover underline for `<amount>` elements.

---
*PR created automatically by Jules for task [5925546761306573240](https://jules.google.com/task/5925546761306573240) started by @john-costanzo*